### PR TITLE
Hide task input placeholder on focus

### DIFF
--- a/app/frontend/src/components/UI/task-input/TaskInput.tsx
+++ b/app/frontend/src/components/UI/task-input/TaskInput.tsx
@@ -53,7 +53,7 @@ const TaskInput: React.FC<Props> = ({ placeholder, onChange }: Props) => {
       <StyledInput
         value={text}
         onChange={ setText }
-        placeholder={ placeholder }
+        placeholder={ !focused ? placeholder : '' }
         onKeyDown={ handleKeyDown }
         onFocus={ onFocus }
         onBlur={ onBlur }


### PR DESCRIPTION
При фокусе на инпуте карточки плейсхолдер скрывается