### PR TITLE
Refactor Icon component to use Sprite

### DIFF
--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import {
   Route
 } from 'react-router-dom';
 import ProjectList from 'components/UI/project-list/ProjectList';
+import Sprite from 'components/UI/sprite/Sprite';
 import SidebarHeader from 'components/layouts/base/SidebarHeader';
 import ProjectView from 'components/views/project-view/ProjectView';
 import { Link } from 'react-router-dom';
@@ -57,6 +58,7 @@ function App(): React.ReactElement {
           <Route path="projects/:id/*" element={ <ProjectView /> } />
         </Route>
       </Routes>
+      <Sprite />
     </Container>
   );
 }

--- a/app/frontend/src/components/UI/icon/Icon.tsx
+++ b/app/frontend/src/components/UI/icon/Icon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { viewBoxes } from 'components/UI/sprite/Sprite';
 
 /**
  * Icon component props
@@ -20,35 +21,10 @@ export interface IconProps extends React.SVGProps<SVGSVGElement> {
  *
  * @param props - props of the component
  */
-const Icon: React.FC<IconProps> = ({ name, ...rest }): JSX.Element | null => {
-  const ImportedIconRef = React.useRef<
-    React.FC<React.SVGProps<SVGSVGElement>>
-  >();
-  const [loading, setLoading] = React.useState(false);
-
-  React.useEffect((): void => {
-    setLoading(true);
-    const importIcon = async (): Promise<void> => {
-      try {
-        // Import path prefixes are flags to force generating ReactComponent named export
-        // see https://github.com/facebook/create-react-app/issues/5276#issuecomment-665628393
-        ImportedIconRef.current = (await import(`@svgr/webpack?-svgo,+titleProp,+ref!icons/${name}.svg`)).ReactComponent;
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    importIcon();
-  }, [ name ]);
-
-  if (!loading && ImportedIconRef.current) {
-    const { current: ImportedIcon } = ImportedIconRef;
-
-    return <ImportedIcon { ...rest }/>;
-  }
-
-  return null;
-};
-
+const Icon: React.FC<IconProps> = ({ name, ...rest }): JSX.Element | null => (
+  <svg { ...rest } preserveAspectRatio="xMidYMid meet" viewBox={ viewBoxes.get(name) }>
+    <use xlinkHref={ `#sprite-${name}` } />
+  </svg>
+);
 
 export default Icon;

--- a/app/frontend/src/components/UI/sprite/Sprite.tsx
+++ b/app/frontend/src/components/UI/sprite/Sprite.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+/**
+ * Icons must be imported separately because some of them may not be used in application
+ * otherwise try to use use following syntax:
+ */
+// eslint-disable-next-line import/no-webpack-loader-syntax
+// import icons from '!!raw-loader!icons/*.svg';
+
+// eslint-disable-next-line import/no-webpack-loader-syntax
+import HomeIcon from '!!raw-loader!icons/home.svg';
+// eslint-disable-next-line import/no-webpack-loader-syntax
+import DefaultAvatar from '!!raw-loader!icons/DefaultAvatar.svg';
+// eslint-disable-next-line import/no-webpack-loader-syntax
+import PlusIcon from '!!raw-loader!icons/plus.svg';
+
+const icons = {
+  'home': HomeIcon,
+  'DefaultAvatar': DefaultAvatar,
+  'plus': PlusIcon,
+};
+
+export const viewBoxes = new Map();
+
+
+// Do not use RegEx to parse XML
+// const getViewBox = (xml) => xml?.match(/viewBox="((\d+(.\d+)? ?)+)"/)?.[1]
+const getViewBox = (xml:string):string => {
+  const doc = new DOMParser().parseFromString(xml, 'text/html');
+
+  return doc?.querySelector('svg')?.getAttribute('viewBox') || '';
+};
+
+const xmlns = 'http://www.w3.org/2000/svg';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const __html = Object.entries(icons)
+  .map(([name, icon]) => {
+    viewBoxes.set(name, getViewBox(icon));
+
+    return icon
+      .replace(`xmlns="${xmlns}"`, `id="sprite-${name}"`)
+      .replaceAll(/\bsvg\b/g, 'symbol');
+  })
+  .join('');
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const Sprite: React.FC = () => <svg xmlns={ xmlns } display="none" dangerouslySetInnerHTML={ { __html } } />;
+
+export default Sprite;


### PR DESCRIPTION
Implements #63

This makes ability to add Icons by their use:link in the SVG sprite

Usage:

```
// Sprite.tsx

// eslint-disable-next-line import/no-webpack-loader-syntax
import HomeIcon from '!!raw-loader!icons/home.svg';
// eslint-disable-next-line import/no-webpack-loader-syntax
import DefaultAvatar from '!!raw-loader!icons/DefaultAvatar.svg';
// eslint-disable-next-line import/no-webpack-loader-syntax
import PlusIcon from '!!raw-loader!icons/plus.svg';

const icons = {
  'home': HomeIcon,
  'DefaultAvatar': DefaultAvatar,
  'plus': PlusIcon,
};
```

```
      /* somewhere in the app's page */
      <Icon name="home" />
      
      /* somewhere on App.tsx */
      <Sprite />
```

<img width="1352" alt="Screenshot 2022-02-04 at 18 23 05" src="https://user-images.githubusercontent.com/175293/152555616-125585f0-f1af-4e9f-9d7c-2cac606ba48b.png">
